### PR TITLE
refactor!: remove duplicate params.output to use single params.outdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ nextflow run \
     ukhsa-collaboration/gpha-mscape-nf-amr \
     -profile docker \
     --samplesheet <SAMPLESHEET.csv> \
-    --output <OUTDIR> \
+    --outdir <OUTDIR> \
     --email <EMAIL> \
     -e.ONYX_DOMAIN=$ONYX_DOMAIN \
     -e.ONYX_TOKEN=$ONYX_TOKEN \
@@ -28,7 +28,7 @@ nextflow run \
     ukhsa-collaboration/gpha-mscape-nf-amr \
     -profile docker \
     --unique_id <UNIQUE_ID> \
-    --output <OUTDIR> \
+    --outdir <OUTDIR> \
     --email <EMAIL> \
     -e.ONYX_DOMAIN=$ONYX_DOMAIN \
     -e.ONYX_TOKEN=$ONYX_TOKEN \

--- a/conf/params.config
+++ b/conf/params.config
@@ -40,7 +40,6 @@ params {
     samplesheet_id_column = 'climb_id'
     samplesheet_columns = 'climb_id,human_filtered_reads_1,human_filtered_reads_2,taxon_reports'
     // samplesheet_columns = 'human_filtered_reads_1,human_filtered_reads_2'
-    output = "mscape-amr-results" // Output directory
     email = null
 
     // Scagaire workflow parameters

--- a/modules/local/onyx_upload.nf
+++ b/modules/local/onyx_upload.nf
@@ -2,7 +2,7 @@
 process ONYX_UPLOAD{
     tag "${unique_id}"
     label 'process_low'
-    publishDir "${params.output}/${unique_id}", mode: 'copy', pattern: "*.json"
+    publishDir "${params.outdir}/${unique_id}", mode: 'copy', pattern: "*.json"
 
     // Onyx and Onyx Helper
     container 'ghcr.io/ukhsa-collaboration/gpha-mscape-onyx-analysis-helper:pr-2'
@@ -16,11 +16,11 @@ process ONYX_UPLOAD{
     
     script:
     """
-    mkdir -p "${params.output}/${unique_id}"
+    mkdir -p "${params.outdir}/${unique_id}"
     
     onyx_upload.py \\
         -i ${unique_id} \\
-        -f ${params.output}/${unique_id} \\
+        -f ${params.outdir}/${unique_id} \\
         -o ./ \\
         --pipeline_status ${pipeline_status} \\
         --amr_params \"tool:${tool},db:${params.arg_abricate_db},minid:${params.arg_abricate_minid},mincov:${params.arg_abricate_mincov}\" \\

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -2,7 +2,7 @@
 process GENERATE_REPORT{
     tag "${climb_id}"
     label 'process_low'
-    publishDir "${params.output}/${climb_id}/", mode: 'copy'
+    publishDir "${params.outdir}/${climb_id}/", mode: 'copy'
 
     // Onyx and Onyx Helper
     container 'community.wave.seqera.io/library/pip_bio_matplotlib_numpy_pruned:489abe68b90e0d56'

--- a/modules/local/samplesheet.nf
+++ b/modules/local/samplesheet.nf
@@ -2,7 +2,7 @@
 process GENERATE_SAMPLESHEET{
     tag "${unique_id}"
     label 'process_low'
-    publishDir "${params.output}/${unique_id}/", mode: 'copy', pattern: "*.csv"
+    publishDir "${params.outdir}/${unique_id}/", mode: 'copy', pattern: "*.csv"
 
     // Onyx and Onyx Helper
     container 'ghcr.io/ukhsa-collaboration/gpha-mscape-onyx-analysis-helper:latest'

--- a/modules/local/taxonomy.nf
+++ b/modules/local/taxonomy.nf
@@ -3,7 +3,7 @@ process READ_ANALYSIS{
     tag "${climb_id}"
     label 'process_low'
     container 'community.wave.seqera.io/library/pip_pandas:40d2e76c16c136f0'
-    publishDir "${params.output}/${climb_id}/", mode: 'copy'
+    publishDir "${params.outdir}/${climb_id}/", mode: 'copy'
 
     // 1. Extract Read IDs from Abricate output file
     input:

--- a/subworkflows/pe_amr_analysis.nf
+++ b/subworkflows/pe_amr_analysis.nf
@@ -9,7 +9,7 @@ workflow PE_AMR_ANALYSIS {
     main:
     paired_end_ch
         .map{ climb_id, kraken_assignments, kraken_report, fastq1, fastq2  ->
-                tuple( climb_id, "${params.output}/${climb_id}", 'Failed', 'None')
+                tuple( climb_id, "${params.outdir}/${climb_id}", 'Failed', 'None')
         }
         .set{ failed_ch }
         ONYX_UPLOAD( failed_ch )


### PR DESCRIPTION
breaking change: `params.outdir` was already set under boilerplate options and is what was being used for pipeline trace dir. This aligns all outputs to use this directory rather then the seperate params.output - which is what is expected for cherami.

updated readme to reflect this change